### PR TITLE
add programIds module

### DIFF
--- a/test-helpers/src/index.ts
+++ b/test-helpers/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./programIds";

--- a/test-helpers/src/programIds.ts
+++ b/test-helpers/src/programIds.ts
@@ -1,0 +1,52 @@
+import { address } from "@solana/addresses";
+
+// Tensor Programs
+export const TCOMP = address("TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp");
+export const TLOCK = address("TLoCKic2wGJm7VhZKumih4Lc35fUhYqVMgA4j389Buk");
+export const TSWAP = address("TSWAPaqyCSx2KABk68Shruf4rp7CxcNi8hAsbdwmHbN");
+export const WHITELIST = address("TL1ST2iRBzuGTqLn1KXnGdSnEow62BzPnGiqyRXhWtW");
+export const TBID = address("TB1Dqt8JeKQh7RLDzfYDJsq8KS4fS2yt87avRjyRxMv");
+
+// SPL Programs
+export const TOKEN = address("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+export const TOKEN22 = address("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+export const ASSOCIATED_TOKEN_ACCOUNTS = address(
+  "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+);
+export const NOOP = address("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
+export const ACCOUNT_COMPRESSION = address(
+  "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK"
+);
+export const MEMO = address("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo");
+
+// Metaplex Programs
+export const MPL_AUCTION_HOUSE = address(
+  "hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk"
+);
+export const MPL_AUCTIONEER = address(
+  "neer8g6yJq2mQM6KbnViEDAD4gr3gRZyMMf4F2p3MEh"
+);
+export const MPL_BUBBLEGUM = address(
+  "BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY"
+);
+export const MPL_CANDY_CORE = address(
+  "CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR"
+);
+export const MPL_CANDY_GUARD = address(
+  "Guard1JwRhJkVH6XZhzoYxeBVQe872VH6QggF4BWmS9g"
+);
+export const MPL_ENGRAVER = address(
+  "ENGRVY4DL6uKDnNS91hCkJMwzTfcofYpkZH8zsgJfzA3"
+);
+export const MPL_INSCRIPTIONS = address(
+  "1NSCRfGeyo7wPUazGbaPBUsTM49e1k2aXewHGARfzSo"
+);
+export const MPL_TOKEN_EXTRAS = address(
+  "TokExjvjJmhKaRBShsBAsbSvEWMA1AgUNK7ps4SAc2p"
+);
+export const MPL_SYSTEM_EXTRAS = address(
+  "SysExL2WDyJi9aRZrXorrjHJut3JwHQ7R9bTyctbNNG"
+);
+export const MPL_TOKEN_METADATA = address(
+  "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+);


### PR DESCRIPTION
Sometimes all you need is just the program ID and don't want to import the entire package for that. Also, currently, there are no packages for Solana SPL programs for the new Web3js 2.0.