### PR TITLE
cleanup

### DIFF
--- a/common-helpers/package.json
+++ b/common-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/common-helpers",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Common helper functions for Tensor SDKs",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",
@@ -29,7 +29,8 @@
     "./dist/types"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"  
   },
   "homepage": "https://github.com/tensor-foundation",
   "repository": "https://github.com/tensor-foundation/toolkit.git",

--- a/compat-helpers/package.json
+++ b/compat-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/compat-helpers",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Helper functions to make old web3.js programs compatible with web3.js-next modules",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",
@@ -29,7 +29,8 @@
     "./dist/types"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "homepage": "https://github.com/tensor-foundation",
   "repository": "https://github.com/tensor-foundation/toolkit.git",
@@ -37,9 +38,9 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@solana/web3.js-next": "npm:@solana/web3.js@^2.0.0-preview.3",
-    "@solana/rpc-spec-types": "^2.0.0-preview.3",
-    "@solana/rpc": "^2.0.0-preview.3",
-    "@solana/rpc-transformers": "^2.0.0-preview.3"
+    "@solana/rpc-spec-types": "2.0.0-preview.3",
+    "@solana/rpc": "2.0.0-preview.3",
+    "@solana/rpc-transformers": "2.0.0-preview.3"
   },
   "peerDependencies": {
     "@solana/web3.js": "<2.0.0",

--- a/mpl-bubblegum/package.json
+++ b/mpl-bubblegum/package.json
@@ -32,7 +32,8 @@
     "validator:stop": "zx ./scripts/stop-validator.mjs"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "homepage": "https://github.com/tensor-foundation",
   "repository": "https://github.com/tensor-foundation/toolkit.git",

--- a/mpl-core/package.json
+++ b/mpl-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/mpl-core",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Toolkit for Metaplex Core",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",
@@ -32,14 +32,15 @@
     "validator:stop": "zx ./scripts/stop-validator.mjs"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "homepage": "https://github.com/tensor-foundation",
   "repository": "https://github.com/tensor-foundation/toolkit.git",
   "author": "Tensor Protocol Foundation <maintainers@tensor.foundation>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tensor-foundation/test-helpers": "0.0.5"
+    "@tensor-foundation/test-helpers": "workspace:*"
   },
   "devDependencies": {
     "@solana/web3.js": "2.0.0-preview.3",

--- a/mpl-token-metadata/package.json
+++ b/mpl-token-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/mpl-token-metadata",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "Toolkit for Metaplex Token Metadata",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",
@@ -32,7 +32,8 @@
     "validator:stop": "zx ./scripts/stop-validator.mjs"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "homepage": "https://github.com/tensor-foundation",
   "repository": "https://github.com/tensor-foundation/toolkit.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "clean": "pnpm --filter common-helpers --filter compat-helpers --filter mpl-core --filter mpl-token-metadata --filter phoenix --filter resolvers --filter test-helpers --filter wns clean",
-    "build": "pnpm --filter common-helpers --filter compat-helpers --filter mpl-core --filter mpl-token-metadata --filter phoenix --filter resolvers --filter test-helpers --filter wns build"
+    "clean": "pnpm --filter common-helpers --filter compat-helpers --filter mpl-core --filter mpl-bubblegum --filter mpl-core --filter mpl-token-metadata --filter phoenix --filter resolvers --filter test-helpers --filter wns clean",
+    "build": "pnpm --filter common-helpers --filter compat-helpers --filter mpl-core --filter mpl-bubblegum --filter mpl-core --filter mpl-token-metadata --filter phoenix --filter resolvers --filter test-helpers --filter wns build"
   }
 }

--- a/phoenix/package.json
+++ b/phoenix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/phoenix",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Toolkit for Phoenix-V1 Program",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",
@@ -32,7 +32,8 @@
     "validator:stop": "zx ./scripts/stop-validator.mjs"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "homepage": "https://github.com/tensor-foundation",
   "repository": "https://github.com/tensor-foundation/toolkit.git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,13 +78,13 @@ importers:
   compat-helpers:
     dependencies:
       '@solana/rpc':
-        specifier: ^2.0.0-preview.3
+        specifier: 2.0.0-preview.3
         version: 2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/rpc-spec-types':
-        specifier: ^2.0.0-preview.3
+        specifier: 2.0.0-preview.3
         version: 2.0.0-preview.3
       '@solana/rpc-transformers':
-        specifier: ^2.0.0-preview.3
+        specifier: 2.0.0-preview.3
         version: 2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/web3.js':
         specifier: <2.0.0
@@ -233,8 +233,8 @@ importers:
   mpl-core:
     dependencies:
       '@tensor-foundation/test-helpers':
-        specifier: 0.0.5
-        version: 0.0.5(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.16.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))
+        specifier: workspace:*
+        version: link:../test-helpers
     devDependencies:
       '@ava/typescript':
         specifier: ^4.1.0
@@ -484,7 +484,7 @@ importers:
         specifier: 2.0.0-preview.3
         version: 2.0.0-preview.3
       '@solana/eslint-config-solana':
-        specifier: ^3.0.3
+        specifier: 3.0.3
         version: 3.0.3(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-react-hooks@4.6.0(eslint@8.57.0))(eslint-plugin-simple-import-sort@10.0.0(eslint@8.57.0))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.2.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@solana/webcrypto-ed25519-polyfill':
         specifier: 2.0.0-preview.3
@@ -526,8 +526,8 @@ importers:
   wns:
     dependencies:
       '@tensor-foundation/test-helpers':
-        specifier: 0.0.5
-        version: 0.0.5(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.16.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))
+        specifier: workspace:*
+        version: link:../test-helpers
     devDependencies:
       '@ava/typescript':
         specifier: ^4.1.0
@@ -1367,11 +1367,6 @@ packages:
   '@supercharge/promise-pool@3.2.0':
     resolution: {integrity: sha512-pj0cAALblTZBPtMltWOlZTQSLT07jIaFNeM8TWoJD1cQMgDB9mcMlVMoetiB35OzNJpqQ2b+QEtwiR9f20mADg==}
     engines: {node: '>=8'}
-
-  '@tensor-foundation/test-helpers@0.0.5':
-    resolution: {integrity: sha512-0nz677l5DjdJVz2oSA1VQk0npPQF+tkFi4LKQvlWxQoVllhCNuGddI7mcD++ARcYM1nIcR0VO1t53mDjZJ/Adw==, tarball: https://npm.pkg.github.com/download/@tensor-foundation/test-helpers/0.0.5/adae61b3fa2402b219071b89b3696281de6a2896}
-    peerDependencies:
-      '@solana/web3.js': 2.0.0-preview.3
 
   '@types/bn.js@5.1.5':
     resolution: {integrity: sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==}
@@ -5455,10 +5450,6 @@ snapshots:
       '@noble/ed25519': 2.1.0
 
   '@supercharge/promise-pool@3.2.0': {}
-
-  '@tensor-foundation/test-helpers@0.0.5(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.16.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))':
-    dependencies:
-      '@solana/web3.js': 2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.16.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
 
   '@types/bn.js@5.1.5':
     dependencies:

--- a/resolvers/package.json
+++ b/resolvers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/resolvers",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "description": "Kinobi resolvers for Tensor protocols",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",

--- a/test-helpers/package.json
+++ b/test-helpers/package.json
@@ -32,7 +32,8 @@
     "validator:stop": "zx ./scripts/stop-validator.mjs"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "homepage": "https://github.com/tensor-foundation",
   "repository": "https://github.com/tensor-foundation/toolkit.git",
@@ -48,7 +49,7 @@
     "@ava/typescript": "^4.1.0",
     "@iarna/toml": "^2.2.5",
     "@noble/hashes": "^1.4.0",
-    "@solana/eslint-config-solana": "^3.0.3",
+    "@solana/eslint-config-solana": "3.0.3",
     "@solana/errors": "2.0.0-preview.3",
     "@solana/webcrypto-ed25519-polyfill": "2.0.0-preview.3",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/wns/package.json
+++ b/wns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/wen-new-standard",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Toolkit for Wen New Standard program",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",
@@ -32,14 +32,15 @@
     "validator:stop": "zx ./scripts/stop-validator.mjs"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "homepage": "https://github.com/tensor-foundation",
   "repository": "https://github.com/tensor-foundation/toolkit.git",
   "author": "Tensor Protocol Foundation <maintainers@tensor.foundation>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tensor-foundation/test-helpers": "0.0.5"
+    "@tensor-foundation/test-helpers": "workspace:*"
   },
   "devDependencies": {
     "@solana/web3.js": "2.0.0-preview.3",


### PR DESCRIPTION
- bump all versions to 0.1.0 (resolvers: 0.1.1)
- set publish registry to npmjs
- set all cross-dependencies to "workspace:*"
- regenerated pnpm-lock.yaml