### PR TITLE
new compat helper for pubkey => noopSigner

### DIFF
--- a/compat-helpers/package.json
+++ b/compat-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/compat-helpers",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Helper functions to make old web3.js programs compatible with web3.js-next modules",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",

--- a/compat-helpers/src/keys.ts
+++ b/compat-helpers/src/keys.ts
@@ -1,9 +1,18 @@
 import { fromLegacyKeypair } from '@solana/compat';
-import { Keypair } from '@solana/web3.js';
-import { createSignerFromKeyPair, KeyPairSigner } from '@solana/web3.js-next';
+import { Keypair, PublicKey } from '@solana/web3.js';
+import { createSignerFromKeyPair, KeyPairSigner, NoopSigner, address } from '@solana/web3.js-next';
 
 export async function fromLegacyKeypairToKeyPairSigner(
   keypair: Keypair
 ): Promise<KeyPairSigner> {
   return await createSignerFromKeyPair(await fromLegacyKeypair(keypair));
+}
+
+export function fromPublicKeyToNoopSigner(publickey: PublicKey): NoopSigner {
+  const out: NoopSigner = {
+      address: address(publickey.toBase58()),
+      signMessages: messages => Promise.resolve(messages.map(() => Object.freeze({}))),
+      signTransactions: transactions => Promise.resolve(transactions.map(() => Object.freeze({}))),
+  };
+  return Object.freeze(out);
 }

--- a/compat-helpers/src/keys.ts
+++ b/compat-helpers/src/keys.ts
@@ -1,6 +1,6 @@
 import { fromLegacyKeypair } from '@solana/compat';
 import { Keypair, PublicKey } from '@solana/web3.js';
-import { createSignerFromKeyPair, KeyPairSigner, NoopSigner, address } from '@solana/web3.js-next';
+import { createSignerFromKeyPair, KeyPairSigner, NoopSigner, address, createNoopSigner } from '@solana/web3.js-next';
 
 export async function fromLegacyKeypairToKeyPairSigner(
   keypair: Keypair
@@ -9,10 +9,5 @@ export async function fromLegacyKeypairToKeyPairSigner(
 }
 
 export function fromPublicKeyToNoopSigner(publickey: PublicKey): NoopSigner {
-  const out: NoopSigner = {
-      address: address(publickey.toBase58()),
-      signMessages: messages => Promise.resolve(messages.map(() => Object.freeze({}))),
-      signTransactions: transactions => Promise.resolve(transactions.map(() => Object.freeze({}))),
-  };
-  return Object.freeze(out);
+  return createNoopSigner(address(publickey.toBase58()));
 }


### PR DESCRIPTION
needed for passing in a TransactionSigner w/o privkey (e.g. dApps) and w/o web3.js-next deps