### PR TITLE
add pNFT prep helper + cleanup

### DIFF
--- a/common-helpers/.eslintrc.cjs
+++ b/common-helpers/.eslintrc.cjs
@@ -3,6 +3,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/sort-type-constituents': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
     'prefer-destructuring': 'off',
     'simple-import-sort/imports': 'off',
     'sort-keys-fix/sort-keys-fix': 'off',

--- a/common-helpers/package.json
+++ b/common-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/common-helpers",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Common helper functions for Tensor SDKs",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",

--- a/common-helpers/src/DAS/helius_queries.ts
+++ b/common-helpers/src/DAS/helius_queries.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { DAS } from 'helius-sdk';
 
 export async function retrieveProofFields(

--- a/common-helpers/src/compression/merkleTree.ts
+++ b/common-helpers/src/compression/merkleTree.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Address, Rpc, SolanaRpcApi } from '@solana/web3.js';
 import { getConcurrentMerkleTreeDecoderFactory } from './codecs/merkleTreeDecoderFactories';
 import { getConcurrentMerkleTreeHeaderDecoder } from './codecs/merkleTreeHeaderDecoder';

--- a/common-helpers/src/constants.ts
+++ b/common-helpers/src/constants.ts
@@ -1,0 +1,5 @@
+import { address } from '@solana/web3.js';
+
+export const MPL_TOKEN_METADATA_PROGRAM_ID = address(
+  'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
+);

--- a/common-helpers/src/metadata/codecs/metadataDecoder.ts
+++ b/common-helpers/src/metadata/codecs/metadataDecoder.ts
@@ -48,7 +48,7 @@ enum Key {
   EditionMarkerV2,
 }
 
-type MetadataData = {
+export type MetadataData = {
   name: string;
   symbol: string;
   uri: string;
@@ -56,19 +56,19 @@ type MetadataData = {
   creators: TCreator[] | null;
 };
 
-type ProgrammableConfigRecord = {
+export type ProgrammableConfigRecord = {
   ruleSet: Address | null;
 };
 
-type ProgrammableConfig = ProgrammableConfigRecord & {
+export type ProgrammableConfig = ProgrammableConfigRecord & {
   __kind: 'V1';
 };
 
-type CollectionDetails =
+export type CollectionDetails =
   | { __kind: 'V1'; size: bigint }
   | { __kind: 'V2'; padding: Array<number> };
 
-type Metadata = {
+export type Metadata = {
   key: Key;
   updateAuthority: Address;
   mint: Address;
@@ -103,26 +103,26 @@ export function getMetadataDecoder(): Decoder<Metadata> {
   ]);
 }
 
-function getCollectionDetailsDecoder(): Decoder<CollectionDetails> {
+export function getCollectionDetailsDecoder(): Decoder<CollectionDetails> {
   return getDiscriminatedUnionDecoder([
     ['V1', getStructDecoder([['size', getU64Decoder()]])],
     ['V2', getStructDecoder([['padding', getArrayDecoder(getU8Decoder())]])],
   ]);
 }
 
-function getProgrammableConfigDecoder(): Decoder<ProgrammableConfig> {
+export function getProgrammableConfigDecoder(): Decoder<ProgrammableConfig> {
   return getDiscriminatedUnionDecoder([
     ['V1', getProgrammableConfigRecordDecoder()],
   ]);
 }
 
-function getProgrammableConfigRecordDecoder(): Decoder<ProgrammableConfigRecord> {
+export function getProgrammableConfigRecordDecoder(): Decoder<ProgrammableConfigRecord> {
   return getStructDecoder([
     ['ruleSet', getNullableDecoder(getAddressDecoder())],
   ]);
 }
 
-function getMetadataDataDecoder(): Decoder<MetadataData> {
+export function getMetadataDataDecoder(): Decoder<MetadataData> {
   return getStructDecoder([
     ['name', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
     ['symbol', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
@@ -132,7 +132,7 @@ function getMetadataDataDecoder(): Decoder<MetadataData> {
   ]);
 }
 
-function getTCreatorDecoder(): Decoder<TCreator> {
+export function getTCreatorDecoder(): Decoder<TCreator> {
   return getStructDecoder([
     ['address', getAddressDecoder()],
     ['verified', getBooleanDecoder()],

--- a/common-helpers/src/metadata/metadata.ts
+++ b/common-helpers/src/metadata/metadata.ts
@@ -1,10 +1,17 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { Address, Rpc, SolanaRpcApi } from '@solana/web3.js';
-import { getMetadataDecoder } from './codecs/metadataDecoder';
+import {
+  Address,
+  GetAccountInfoApi,
+  getAddressEncoder,
+  getProgramDerivedAddress,
+  getUtf8Encoder,
+  Rpc,
+} from '@solana/web3.js';
+import { getMetadataDecoder, Metadata } from './codecs/metadataDecoder';
+import { MPL_TOKEN_METADATA_PROGRAM_ID } from '../constants';
 
 // fetches ruleset given metadataPda
 export async function getRulesetFromMetadataPda(
-  rpc: Rpc<SolanaRpcApi>,
+  rpc: Rpc<GetAccountInfoApi>,
   metadataPda: Address
 ) {
   const decodedMetadataData = await fetchMetadata(rpc, metadataPda);
@@ -13,7 +20,7 @@ export async function getRulesetFromMetadataPda(
 
 // fetches and deserializes data stored on given metadataPda into Metadata
 export async function fetchMetadata(
-  rpc: Rpc<SolanaRpcApi>,
+  rpc: Rpc<GetAccountInfoApi>,
   metadataPda: Address
 ): Promise<any> {
   const metadataData = await rpc
@@ -22,4 +29,35 @@ export async function fetchMetadata(
     .then((result: any) => result.value.data[0]);
   const metadataDataBytes = Buffer.from(metadataData, 'base64');
   return getMetadataDecoder().decode(metadataDataBytes);
+}
+
+export type PrepPnftMetadataResult = {
+  metadataPda: Address;
+  metadata: Metadata;
+  ruleset: Address | undefined;
+};
+
+// fetches metadata and ruleset for a given mint
+export async function prepPnftMetadata(
+  rpc: Rpc<GetAccountInfoApi>,
+  mint: Address
+) {
+  const [metadataPda] = await findMetadataPda(mint);
+  const metadata: Metadata = await fetchMetadata(rpc, metadataPda);
+  const ruleset = metadata.programmableConfig?.ruleSet ?? undefined;
+  return { metadataPda, metadata, ruleset };
+}
+
+export async function findMetadataPda(
+  mint: Address,
+  programId: Address = MPL_TOKEN_METADATA_PROGRAM_ID
+) {
+  return await getProgramDerivedAddress({
+    programAddress: programId,
+    seeds: [
+      getUtf8Encoder().encode('metadata'),
+      getAddressEncoder().encode(programId),
+      getAddressEncoder().encode(mint),
+    ],
+  });
 }

--- a/common-helpers/src/transactions/simulateInstructions.ts
+++ b/common-helpers/src/transactions/simulateInstructions.ts
@@ -1,9 +1,11 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
+  GetLatestBlockhashApi,
   IInstruction,
   KeyPairSigner,
   Rpc,
-  SolanaRpcApi,
+  SendTransactionApi,
+  Signature,
+  SimulateTransactionApi,
   appendTransactionMessageInstruction,
   compileTransaction,
   createTransactionMessage,
@@ -11,13 +13,14 @@ import {
   pipe,
   setTransactionMessageFeePayer,
   setTransactionMessageLifetimeUsingBlockhash,
+  signTransaction,
 } from '@solana/web3.js';
 
 export async function simulateTxWithIxs(
-  rpc: Rpc<SolanaRpcApi>,
+  rpc: Rpc<SimulateTransactionApi & GetLatestBlockhashApi>,
   ixs: IInstruction[],
   signer: KeyPairSigner
-): Promise<void> {
+): Promise<ReturnType<SimulateTransactionApi['simulateTransaction']>> {
   const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
   const simPipe = pipe(
     createTransactionMessage({ version: 0 }),
@@ -30,12 +33,39 @@ export async function simulateTxWithIxs(
     (tx) => compileTransaction(tx),
     (tx) => getBase64EncodedWireTransaction(tx)
   );
-  const simulationResponse = await rpc
+  return await rpc
     .simulateTransaction(simPipe, {
       encoding: 'base64',
       sigVerify: false,
       replaceRecentBlockhash: true,
     })
     .send();
-  console.log(simulationResponse);
+}
+
+export async function sendTxWithIxs(
+  rpc: Rpc<SendTransactionApi & GetLatestBlockhashApi>,
+  ixs: IInstruction[],
+  signer: KeyPairSigner
+): Promise<Signature> {
+  const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+  const txBytes = await pipe(
+    createTransactionMessage({ version: 0 }),
+    // maps each instruction to an lambda expression that looks like: (tx) => appendTransactionInstruction(instruction, tx),
+    ...(ixs.map(
+      (ix) => (tx: any) => appendTransactionMessageInstruction(ix, tx)
+    ) as []),
+    (tx) => setTransactionMessageFeePayer(signer.address, tx),
+    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+    (tx) => compileTransaction(tx),
+    async (tx) =>
+      await signTransaction([signer.keyPair], tx).then((tx) =>
+        getBase64EncodedWireTransaction(tx)
+      )
+  );
+
+  return await rpc
+    .sendTransaction(txBytes, {
+      encoding: 'base64',
+    })
+    .send();
 }


### PR DESCRIPTION
- adds `prepPnftMetadata` (web3js 2.0 equivalent to https://github.com/tensor-hq/tensor-common/blob/43297c077ca71c560ee8c5ee416a2b5233c05d68/src/metaplex/token_rules.ts#L20)
- lil bit of cleanup
- also adds sendTxWithIxs helper (equiv to simulateTxWithIxs but actually sends the tx payload to rpc)